### PR TITLE
Initial release of kitchen-opennebula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0 / Unreleased
+
+* Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Author:: Andrew J. Brown (<anbrown@blackberry.com>)
+
+Copyright (C) 2014, BlackBerry, Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,128 @@
 
 A Test Kitchen Driver for Opennebula.
 
+## <a name="requirements"></a> Requirements
+
+This driver depends on BlackBerry patches to Fog (https://github.com/fog/fog)
+for better support for OpenNebula.  These patches can be found at
+https://github.com/blackberry/fog until they are merged to upstream.
+
+## <a name="installation"></a> Installation and Setup
+
+Please read the [Driver usage][driver_usage] page for more details.
+
+## Virtual Machine Requirements
+
+This driver requires an OpenNebula OS image that conforms to a number of requirements
+
+* The VM puts the ssh key defined in the SSH\_PUBLIC\_KEY context variable into `$HOME/.ssh/authorized_keys`
+* The VM ensures the user has passwordless sudo access
+
+## <a name="config"></a> Configuration
+
+### <a name="opennebula_endpoint"></a> opennebula\_endpoint
+
+URL where the OpenNebula daemon is listening.  
+The default value is taken from the ONE\_XMLRPC environment variable, or `http://127.0.0.1:2633/RPC2` if unset.
+
+### <a name="oneauth_file"></a> oneauth\_file
+
+Path to the file containing OpenNebula authentication information.  It should contain a single line stating "username:password".
+The default value is taken from the ONE\_AUTH environment variable, or `$HOME/.one/one_auth` if unset.
+
+### <a name="template_name"></a> template\_name
+
+Name of the VM definition file (OpenNebula template) registered with OpenNebula.  Can be used with `template_uname` or `template_uid` to further restrict which template to use if multiple users have the same template name.  Only one of `template_name` or `template_id` must be specified in the .kitchen.yml file.
+The default value is unset, or `nil`.
+
+### <a name="template_id"></a> template\_id
+
+ID of the VM definition file (OpenNebula template) registered with OpenNebula.  Only one of `template_name` or `template_id` must be specified in the .kitchen.yml file.
+The default value is unset, or `nil`.
+
+### <a name="template_uname"></a> template\_uname
+
+Username who owns the VM definition file (OpenNebula template).  Can be used with `template_name` to address naming conflicts where multiple users have the same template name.
+The default value is unset, or `nil`.
+
+### <a name="template_uid"></a> template\_uid
+
+UID of the user who owns the VM definition file (OpenNebula template).  Can be used with `template_name` to address naming conflicts where multiple users have the same template name.
+The default value is unset, or `nil`.
+
+### <a name="vm_hostname"></a> vm\_hostname
+
+Hostname to set for the newly created VM.
+The default value is `driver.instance.name`
+
+### <a name="public_key_path"></a> public\_key\_path
+
+Path to SSH public key to pass to the VM, to use to authenticate with `username` when logging in or converging a node.
+The default value is `~/.ssh/id_rsa.pub`, `~/.ssh/id_dsa.pub`, `~/.ssh/identity.pub`, or `~/.ssh/id_ecdsa.pub`, whichever is present on the filesystem.
+
+### <a name="username"></a> username
+
+This is the username used for SSH authentication to the new VM.
+The default value is `local`.
+
+### <a name="memory"></a> memory
+
+The amount of memory to provision for the new VM.  This parameter will override the memory settings provided in the VM template.
+The default value is 512MB.
+
+### <a name="user_variables"></a> user\_variables
+
+A hash of variables to pass into the "user template" section of the VM, to customize the virtual machine.
+The default value is `{}`.
+
+### <a name="context_variables"></a> context\_variables
+
+A hash of variables to pass into the "CONTEXT" section of the VM, to further customize the virtual machine.  These variables override any existing context variables that are provided as part of the specified VM template.
+The default value is `{}`.
+
+### <a name="config-require-chef-omnibus"></a> require\_chef\_omnibus
+
+Determines whether or not a Chef [Omnibus package][chef_omnibus_dl] will be
+installed. There are several different behaviors available:
+
+* `true` - the latest release will be installed. Subsequent converges
+  will skip re-installing if chef is present.
+* `latest` - the latest release will be installed. Subsequent converges
+  will always re-install even if chef is present.
+* `<VERSION_STRING>` (ex: `10.24.0`) - the desired version string will
+  be passed the the install.sh script. Subsequent converges will skip if
+  the installed version and the desired version match.
+* `false` or `nil` - no chef is installed.
+
+The default value is unset, or `nil`.
+
+## <a name="development"></a> Development
+
+* Source hosted at [GitHub][repo]
+* Report issues/questions/feature requests on [GitHub Issues][issues]
+
+Pull requests are very welcome! Make sure your patches are well tested.
+Ideally create a topic branch for every separate change you make. For
+example:
+
+1. Fork the repo
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## <a name="authors"></a> Authors
+
+Created and maintained by [Andrew Brown][author] (<anbrown@blackberry.com>)
+
+## <a name="license"></a> License
+
+Apache 2.0 (see [LICENSE][license])
+
+
+[author]:           https://github.com/andrewjamesbrown
+[issues]:           https://github.com/test-kitchen/kitchen-opennebula/issues
+[license]:          https://github.com/test-kitchen/kitchen-opennebula/blob/master/LICENSE
+[repo]:             https://github.com/test-kitchen/kitchen-opennebula
+[driver_usage]:     http://docs.kitchen-ci.org/drivers/usage
+[chef_omnibus_dl]:  http://www.getchef.com/chef/install/

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+require "bundler/gem_tasks"
+require 'cane/rake_task'
+require 'tailor/rake_task'
+
+desc "Run cane to check quality metrics"
+Cane::RakeTask.new do |cane|
+  cane.canefile = './.cane'
+end
+
+Tailor::RakeTask.new
+
+desc "Display LOC stats"
+task :stats do
+  puts "\n## Production Code Stats"
+  sh "countloc -r lib"
+end
+
+desc "Run all quality tasks"
+task :quality => [:cane, :tailor, :stats]
+
+task :default => [:quality]

--- a/kitchen-opennebula.gemspec
+++ b/kitchen-opennebula.gemspec
@@ -1,0 +1,29 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'kitchen/driver/opennebula_version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'kitchen-opennebula'
+  spec.version       = Kitchen::Driver::OPENNEBULA_VERSION
+  spec.authors       = ['Andrew J. Brown']
+  spec.email         = ['anbrown@blackberry.com']
+  spec.description   = %q{A Test Kitchen Driver for Opennebula}
+  spec.summary       = spec.description
+  spec.homepage      = ''
+  spec.license       = 'Apache 2.0'
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = []
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'test-kitchen', '~> 1.2.0'
+
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
+
+  spec.add_development_dependency 'cane'
+  spec.add_development_dependency 'tailor'
+  spec.add_development_dependency 'countloc'
+end

--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -1,0 +1,139 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Andrew J. Brown (<anbrown@blackberry.com>)
+#
+# Copyright (C) 2014, BlackBerry, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'fog'
+require 'kitchen'
+
+module Kitchen
+
+  module Driver
+
+    # Opennebula driver for Kitchen.
+    #
+    # @author Andrew J. Brown <anbrown@blackberry.com>
+    class Opennebula < Kitchen::Driver::SSHBase
+      default_config :opennebula_endpoint,
+        ENV.fetch('ONE_XMLRPC', 'http://127.0.0.1:2633/RPC2')
+
+      default_config :oneauth_file,
+        ENV.fetch('ONE_AUTH', "#{ENV['HOME']}/.one/one_auth")
+
+      default_config :vm_hostname do |driver|
+        "#{driver.instance.name}"
+      end
+
+      default_config :public_key_path do
+        [
+          File.expand_path('~/.ssh/id_rsa.pub'),
+          File.expand_path('~/.ssh/id_dsa.pub'),
+          File.expand_path('~/.ssh/identity.pub'),
+          File.expand_path('~/.ssh/id_ecdsa.pub')
+        ].find { |path| File.exist?(path) }
+      end
+
+      default_config :username, 'local'
+      default_config :memory, 512
+      default_config :user_variables, { }
+      default_config :context_variables, { }
+
+      def create(state)
+        conn = opennebula_connect
+
+        # Check if VM is already created.
+        if state[:vm_id] && !conn.list_vms({:id => state[:vm_id]}).empty?
+          info("OpenNebula instance #{instance.to_str} already created.")
+          return
+        end
+   
+        if config[:template_id].nil? and config[:template_name].nil? 
+          raise "template_name or template_id not specified in .kitchen.yml"
+        elsif !config[:template_id].nil? and !config[:template_name].nil?
+          raise "Only one of template_name or template_id should be specified in .kitchen.yml"
+        end
+
+        newvm = conn.servers.new
+        if config[:template_id]
+          newvm.flavor = conn.flavors.get config[:template_id]
+        elsif config[:template_name]
+          filter = {
+            :name  => config[:template_name],
+            :uname => config[:template_uname],
+            :uid   => config[:template_uid]
+          }
+          newvm.flavor = conn.flavors.get_by_filter filter
+        end
+        if newvm.flavor.nil?
+          raise "Could not find template to create VM."
+        end
+        newvm.flavor = newvm.flavor.first
+        newvm.name = config[:vm_hostname]
+        newvm.flavor.user_variables = config[:user_variables]
+        newvm.flavor.context['SSH_PUBLIC_KEY'] = File.read(config[:public_key_path]).chomp
+        newvm.flavor.context['TEST_KITCHEN'] = "YES"
+
+        # Support for overriding context variables in the VM template
+        config[:context_variables].each do |key, val|
+          newvm.flavor.context[key] = val
+        end
+        newvm.flavor.memory = config[:memory]
+       
+        # TODO: Set up NIC and disk if not specified in template
+        vm = newvm.save
+        vm.wait_for { ready? }
+        state[:vm_id] = vm.id
+        state[:hostname] = vm.ip
+        state[:username] = config[:username]
+        info("OpenNebula instance #{instance.to_str} created.")
+      end
+
+      def converge(state)
+        super
+      end
+
+      def verify(state)
+        super
+      end
+
+      def destroy(state)
+        conn = opennebula_connect
+        conn.servers.destroy(state[:vm_id])
+      end
+
+      protected
+
+      def opennebula_connect()        
+        opennebula_creds = nil
+        if File.exists?(config[:oneauth_file])
+          opennebula_creds = File.read(config[:oneauth_file])
+        else
+          raise ActionFailed, "Could not find one_auth file #{config[:oneauth_file]}"
+        end
+        opennebula_username = opennebula_creds.split(':')[0]
+        opennebula_password = opennebula_creds.split(':')[1]
+        conn = Fog::Compute.new( {
+          :provider => 'OpenNebula',
+          :opennebula_username => opennebula_username,
+          :opennebula_password => opennebula_password,
+          :opennebula_endpoint => config[:opennebula_endpoint]
+        } )
+        conn
+      end
+
+   end
+  end
+end

--- a/lib/kitchen/driver/opennebula_version.rb
+++ b/lib/kitchen/driver/opennebula_version.rb
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Andrew Brown (<anbrown@blackberry.com>)
+#
+# Copyright (C) 2014, BlackBerry, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Kitchen
+
+  module Driver
+
+    # Version string for Opennebula Kitchen driver
+    OPENNEBULA_VERSION = "0.1.0.dev"
+  end
+end


### PR DESCRIPTION
This driver provides OpenNebula support to Test Kitchen.  It is not
fully featured, but is functional.  The use of this gem requires
BlackBerry patches to Fog, available at
https://github.com/blackberry/fog/tree/opennebula
