### PR TITLE
Adding a server length check to the connection to help debug possible…

### DIFF
--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -65,6 +65,11 @@ module Kitchen
       def create(state)
         conn = opennebula_connect
 
+        # Check for servers from connection to help debug possible connection issues
+        if conn.servers.length == 0
+          info("Connection has returned zero servers.")
+        end
+
         # Check if VM is already created.
         if state[:vm_id] && !conn.list_vms({:id => state[:vm_id]}).empty?
           info("OpenNebula instance #{instance.to_str} already created.")
@@ -93,7 +98,7 @@ module Kitchen
           newvm.flavor = newvm.flavor.first unless newvm.flavor.nil?
         end
         if newvm.flavor.nil?
-          raise "Could not find template to create VM."
+          raise "Could not find template to create VM. -- Verify your template filters and one_auth credentials"
         end
         newvm.name = config[:vm_hostname]
         


### PR DESCRIPTION
… connection issues. Making the flavor exception when no template matching filter found to be more verbose and help debug filters that aren't found.

I browsed through the fog library and didn't find anything that could validate credentials before using the connection (and there might be a better way to do that!)
Also worth nothing that it takes a ridiculously long time to pull up the flavors via 'conn.flavors', which is why I don't bother with an explicit check on the connection flavors, since if it IS populated, would add unnecessary overhead.

Overall, just a change to help users debug the "Could not find template to create VM" exception, even though it's technically accurate, it's caused by the fact that a user's credentials may be wrong (but has no indication of it!)