### PR TITLE
Version 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Restrict opennebula gem dependency version to be '~> 4.10', '< 5'.
+
 ## 0.2.1
 
 * Do not use methods from Kitchen::SSHBase as we are no longer inherit them. Rely on instance.transport instead.

--- a/kitchen-opennebula.gemspec
+++ b/kitchen-opennebula.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'test-kitchen', '~> 1.2'
   spec.add_dependency 'fog', '~> 1.30'
-  spec.add_dependency 'opennebula'
+  spec.add_dependency 'opennebula', '~> 4.10', '< 5'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/kitchen/driver/opennebula_version.rb
+++ b/lib/kitchen/driver/opennebula_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Opennebula Kitchen driver
-    OPENNEBULA_VERSION = "0.2.1"
+    OPENNEBULA_VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
- Put restriction on opennebula gem dependency as version 5.x.x is currently not supported.