### PR TITLE
update version requirements and add random string to instances

### DIFF
--- a/kitchen-opennebula.gemspec
+++ b/kitchen-opennebula.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'test-kitchen', '~> 1.2'
   spec.add_dependency 'fog', '~> 1.30'
-  spec.add_dependency 'opennebula', '~> 4.10', '< 5'
+  spec.add_dependency 'opennebula'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/kitchen-opennebula.gemspec
+++ b/kitchen-opennebula.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'test-kitchen', '~> 1.2'
   spec.add_dependency 'fog', '~> 1.30'
-  spec.add_dependency 'opennebula'
+  spec.add_dependency 'opennebula', '>= 4.10'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -49,6 +49,8 @@ module Kitchen
 
       default_config :username, 'local'
       default_config :memory, 512
+      default_config :vcpu, 1
+      default_config :cpu, 1
       default_config :user_variables, { }
       default_config :context_variables, { }
 
@@ -115,6 +117,8 @@ module Kitchen
           newvm.flavor.context[key.to_s] = val
         end
         newvm.flavor.memory = config[:memory]
+        newvm.flavor.vcpu = config[:vcpu]
+        newvm.flavor.cpu = config[:cpu]
        
         # TODO: Set up NIC and disk if not specified in template
         vm = newvm.save

--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -34,7 +34,8 @@ module Kitchen
         ENV.fetch('ONE_AUTH', "#{ENV['HOME']}/.one/one_auth")
 
       default_config :vm_hostname do |driver|
-        "#{driver.instance.name}"
+        randstr = 8.times.collect{[*'a'..'z',*('0'..'9')].sample}.join
+        "#{driver.instance.name}-#{randstr}"
       end
 
       default_config :public_key_path do

--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -175,13 +175,16 @@ module Kitchen
 
       def opennebula_connect()        
         opennebula_creds = nil
-        if File.exists?(config[:oneauth_file])
+        if ENV.has_key?('ONEAUTH_USERNAME') and ENV.has_key?('ONEAUTH_PASSWORD')
+          opennebula_username = ENV['ONEAUTH_USERNAME']
+          opennebula_password = ENV['ONEAUTH_PASSWORD']
+        elsif File.exists?(config[:oneauth_file])
           opennebula_creds = File.read(config[:oneauth_file])
+          opennebula_username = opennebula_creds.split(':')[0]
+          opennebula_password = opennebula_creds.split(':')[1]
         else
           raise ActionFailed, "Could not find one_auth file #{config[:oneauth_file]}"
         end
-        opennebula_username = opennebula_creds.split(':')[0]
-        opennebula_password = opennebula_creds.split(':')[1]
         conn = Fog::Compute.new( {
           :provider => 'OpenNebula',
           :opennebula_username => opennebula_username,

--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -179,16 +179,18 @@ module Kitchen
 
       def opennebula_connect()        
         opennebula_creds = nil
-        if ENV.has_key?('ONEAUTH_USERNAME') and ENV.has_key?('ONEAUTH_PASSWORD')
-          opennebula_username = ENV['ONEAUTH_USERNAME']
-          opennebula_password = ENV['ONEAUTH_PASSWORD']
+        if ENV.has_key?('ONE_AUTH')
+          if File.exists(ENV['ONE_AUTH'])
+            opennebula_creds = File.read(ENV['ONE_AUTH'])
+          else
+            opennebula_creds = ENV['ONE_AUTH']
         elsif File.exists?(config[:oneauth_file])
           opennebula_creds = File.read(config[:oneauth_file])
-          opennebula_username = opennebula_creds.split(':')[0]
-          opennebula_password = opennebula_creds.split(':')[1]
         else
           raise ActionFailed, "Could not find one_auth file #{config[:oneauth_file]}"
         end
+        opennebula_username = opennebula_creds.split(':')[0]
+        opennebula_password = opennebula_creds.split(':')[1]
         conn = Fog::Compute.new( {
           :provider => 'OpenNebula',
           :opennebula_username => opennebula_username,


### PR DESCRIPTION
I have tested this on 5.2.1, and it all works correctly.

Also, a random string should be added to the instance name, so that this can be run more than once at the same time without overwritting each other.